### PR TITLE
Feature/add line number in result

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-preset-stage-1": "^6.1.18",
     "babel-standalone": "^6.7.7",
     "esprima": "^2.7.2",
-    "lodash": "^3.10.1",
+    "lodash": "^4.13.1",
     "react": "^0.14.3",
     "react-addons-create-fragment": "^15.1.0",
     "react-codemirror": "^0.2.6",

--- a/src/components/viewer.js
+++ b/src/components/viewer.js
@@ -22,9 +22,24 @@ class Viewer extends Component {
       return result;
     });
 
-    return _.map(formattedExpressions, (expression, line) =>
-      <div>{expression}</div>
+    const lineNumberLength = _.reduce(
+      _.keys(formattedExpressions),
+      (len, line) => line.length > len ? line.length : len,
+      0
     );
+
+    return _.map(formattedExpressions, (expression, line) => {
+      const lineString = _.padStart(line.toString(), lineNumberLength, '\u00A0');
+      if(expression){
+        return(
+          <div className="result__line">
+            <div className="result___line-number">{lineString}</div>
+            <div className="result___expression">{expression}</div>
+          </div>
+        );
+      }
+      return ;
+    });
   }
 
   renderExpressions(code) {

--- a/src/selectors/parse_expressions.js
+++ b/src/selectors/parse_expressions.js
@@ -17,7 +17,10 @@ const findDelimiters = ({ column }, lineContents) =>
   _.intersection(_.takeRight(lineContents, lineContents.length - column), OPEN_DELIMITERS).length
 
 const parseExpressions = (code) => {
-  const transformedCode = transform(code, { presets: ['react']}).code;
+  const transformedCode = transform(code, {
+    presets: ['react'],
+    retainLines: true
+  }).code;
   const codeByLine = transformedCode.split('\n');
   const tokenized = esprima.tokenize(transformedCode, { loc: true });
 

--- a/style/style.css
+++ b/style/style.css
@@ -405,3 +405,34 @@ cursor: not-allowed;
 Resizer.disabled:hover {
 border-color: transparent;
 }
+
+/* result */
+.result{
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.result__line{
+  display: flex;
+}
+
+.result__line:last-child{
+  flex: 1;
+}
+
+.result___line-number{
+  border-right: 1px solid #ddd;
+  background-color: #f7f7f7;
+  white-space: nowrap;
+  font-family: monospace;
+  padding: 0 3px 0 5px;
+  color: #999;
+  min-width: 30px;
+  text-align: right;
+  margin-right: 10px;
+}
+
+.result___expression{
+  flex: 1;
+}


### PR DESCRIPTION
This PR adds line numbers in the view/result in order to clarify which line is the result of which line in the code :

![image](https://cloud.githubusercontent.com/assets/5002260/16895914/2b11dbb2-4b84-11e6-8d22-007a84a9feb0.png)

What do you think ?
