### PR TITLE
When typing "exp" the app crashes

### DIFF
--- a/src/selectors/parse_expressions.js
+++ b/src/selectors/parse_expressions.js
@@ -55,8 +55,8 @@ const parseExpressions = (code) => {
 
     return expressions;
   }, {});
-
-  eval(transformedCode);
+  const evalNoScope = eval.bind();
+  evalNoScope(transformedCode);
   return exp;
 }
 


### PR DESCRIPTION
If you type `exp` the app will crash.
The reason is `exp` is a variable that exists in `parse_expressions.js` so when checking this expression it passes however it crashes in the "real" eval at `viewer.js`.
Same error happends if you type 
* code
* transformedCode
* codeByLine
* tokenized 
... and more 
